### PR TITLE
Enable input for Kromek SPE

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,6 @@
 ## gammaShiny 0.1.0.9000
+* Enable support for Kromek `.spe` file format.
+
 
 ## gammaShiny 0.1.0
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.4139006.svg)](https://doi.org/10.5281/zenodo.4139006)

--- a/R/module_import_ui.R
+++ b/R/module_import_ui.R
@@ -20,7 +20,7 @@ module_import_ui <- function(id) {
               inputId = ns("files"),
               label = "Import spectrum file(s)",
               multiple = TRUE,
-              accept = c(".cnf", ".CNF", ".tka", ".TKA")
+              accept = c(".cnf", ".CNF", ".tka", ".TKA", ".spe", ".SPE")
             ),
             tags$hr(),
             shinyWidgets::pickerInput(


### PR DESCRIPTION
Enable `.spe` support for Kromek files.

## Description
+ up module_import()
+ up NEWS

## Related Issue
https://github.com/crp2a/gamma/pull/28
